### PR TITLE
Feature/setup back front multiple add to cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ make generate-entity-scaffolding name=ModelName
 
 ##### 👤 Authenticated Users
 - Add products to cart: ➕
+- Add multiple products to cart ➕
 - Update quantities: ⬆️⬇️
 - Remove products: 🗑️
 - Clear cart completely: 🧹

--- a/back/app/Http/Controllers/CartController.php
+++ b/back/app/Http/Controllers/CartController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Cart\AddMultipleItemsRequest;
 use App\Models\Product;
 use App\Services\CartService;
 use App\Services\CartSessionService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 
 class CartController extends Controller
@@ -19,6 +21,39 @@ class CartController extends Controller
     public function get(): JsonResponse
     {
         return response()->json($this->cartService->getCart());
+    }
+
+    public function addMultipleItems(AddMultipleItemsRequest $request): JsonResponse
+    {
+        $productIds = collect($request->validated('items'))
+            ->pluck('product_id')
+            ->unique()
+            ->toArray();
+
+        $products = Product::whereIn('id', $productIds)
+            ->get()
+            ->keyBy('id');
+
+        $productsData = collect($request->validated('items'))
+            ->map(function ($item) use ($products) {
+                $product = $products->get($item['product_id']);
+
+                if (! $product) {
+                    throw new ModelNotFoundException(
+                        __('Product with ID :id not found', ['id' => $item['product_id']])
+                    );
+                }
+
+                return [
+                    'product' => $product,
+                    'quantity' => $item['quantity'],
+                ];
+            })
+            ->toArray();
+
+        $cart = $this->cartService->addMultipleItems($productsData);
+
+        return response()->json($cart);
     }
 
     public function addItem(Product $product): JsonResponse

--- a/back/app/Http/Requests/Cart/AddMultipleItemsRequest.php
+++ b/back/app/Http/Requests/Cart/AddMultipleItemsRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Cart;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddMultipleItemsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'items' => 'required|array|max:100',
+            'items.*.product_id' => [
+                'required',
+                'integer',
+            ],
+            'items.*.quantity' => [
+                'required',
+                'integer',
+                'min:1',
+                'max:100',
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'items.max' => __('You can add a maximum of :max items at once.'),
+            'items.*.product_id.exists' => __('One or more products are invalid or not available.'),
+            'items.*.quantity.max' => __('Maximum quantity per item is :max.'),
+        ];
+    }
+}

--- a/back/app/Repositories/CartRepository.php
+++ b/back/app/Repositories/CartRepository.php
@@ -3,8 +3,10 @@
 namespace App\Repositories;
 
 use App\Models\Cart;
+use App\Models\CartItem;
 use App\Models\Product;
 use App\Services\Contracts\CartRepositoryInterface;
+use Illuminate\Support\Facades\DB;
 
 class CartRepository implements CartRepositoryInterface
 {
@@ -22,6 +24,78 @@ class CartRepository implements CartRepositoryInterface
     public function create(array $data): object
     {
         return Cart::create($data);
+    }
+
+    public function addMultipleItems(object $cart, array $products): object
+    {
+        return DB::transaction(function () use ($cart, $products) {
+            $productIds = array_map(fn ($item) => $item['product']->id, $products);
+
+            $existingItems = $cart->cartItems()
+                ->whereIn('product_id', $productIds)
+                ->get()
+                ->keyBy('product_id');
+
+            $bulkUpdateData = [];
+            $bulkInsertData = [];
+
+            foreach ($products as $productData) {
+                $product = $productData['product'];
+                $quantity = $productData['quantity'];
+
+                $existingItem = $existingItems->get($product->id);
+
+                if ($existingItem) {
+                    $bulkUpdateData[] = [
+                        'id' => $existingItem->id,
+                        'quantity' => $existingItem->quantity + $quantity,
+                    ];
+                } else {
+                    $bulkInsertData[] = [
+                        'cart_id' => $cart->id,
+                        'product_id' => $product->id,
+                        'quantity' => $quantity,
+                        'price' => $product->price,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+            }
+
+            if (! empty($bulkUpdateData)) {
+                $this->bulkUpdateCartItemQuantities($bulkUpdateData);
+            }
+
+            if (! empty($bulkInsertData)) {
+                CartItem::insert($bulkInsertData);
+            }
+
+            $cart->refresh();
+
+            return $cart;
+        });
+    }
+
+    private function bulkUpdateCartItemQuantities(array $updateData): void
+    {
+        $cases = [];
+        $ids = [];
+
+        foreach ($updateData as $item) {
+            $cases[] = "WHEN {$item['id']} THEN {$item['quantity']}";
+            $ids[] = $item['id'];
+        }
+
+        $ids = implode(',', $ids);
+        $cases = implode(' ', $cases);
+
+        DB::statement("
+            UPDATE cart_items
+            SET quantity = CASE id
+                {$cases}
+                END
+            WHERE id IN ({$ids})
+        ");
     }
 
     public function addItem(object $cart, Product $product, int $quantity): object

--- a/back/app/Services/CartService.php
+++ b/back/app/Services/CartService.php
@@ -43,6 +43,14 @@ readonly class CartService
         return $cart;
     }
 
+    public function addMultipleItems(array $products): array
+    {
+        $cart = $this->getCurrentCart();
+        $updatedCart = $this->cartRepository->addMultipleItems($cart, $products);
+
+        return $this->getCartDetails($updatedCart);
+    }
+
     public function addItem(Product $product, int $quantity = 1): array
     {
         $cart = $this->getCurrentCart();

--- a/back/app/Services/Contracts/CartRepositoryInterface.php
+++ b/back/app/Services/Contracts/CartRepositoryInterface.php
@@ -10,6 +10,8 @@ interface CartRepositoryInterface
 
     public function create(array $data): object;
 
+    public function addMultipleItems(object $cart, array $products): object;
+
     public function addItem(object $cart, Product $product, int $quantity): object;
 
     public function removeItem(object $cart, Product $product): void;

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -14,6 +14,7 @@ Route::post('products/list', ProductController::class)->name('products.list');
 Route::prefix('cart')->group(function () {
     Route::get('/', [CartController::class, 'get'])->name('api.cart.get');
     Route::post('add/{product}', [CartController::class, 'addItem'])->name('api.cart.add');
+    Route::post('add-multiple', [CartController::class, 'addMultipleItems'])->name('api.cart.add.multiple');
     Route::delete('remove/{product}', [CartController::class, 'removeItem'])->name('api.cart.remove');
     Route::put('update/{product}/{quantity}', [CartController::class, 'updateQuantity'])->name('api.cart.update');
     Route::delete('clear', [CartController::class, 'clear'])->name('api.cart.clear');

--- a/back/tests/Feature/CartRepositoryTest.php
+++ b/back/tests/Feature/CartRepositoryTest.php
@@ -123,3 +123,125 @@ test('can clear cart', function () {
     $cart->refresh();
     expect($cart->cartItems)->toHaveCount(0);
 });
+
+test('can add multiple different items to an empty cart', function () {
+    $products = Product::factory()->count(3)->create([
+        'price' => 19.99,
+    ]);
+
+    $cart = Cart::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $itemsToAdd = $products->map(function ($product) {
+        return [
+            'product' => $product,
+            'quantity' => 2,
+        ];
+    })->toArray();
+
+    $updatedCart = $this->cartRepository->addMultipleItems($cart, $itemsToAdd);
+
+    expect($updatedCart->cartItems)->toHaveCount(3)
+        ->and($updatedCart->cartItems->pluck('quantity')->toArray())->toBe([2, 2, 2])
+        ->and($updatedCart->cartItems->pluck('product_id')->toArray())->toBe(
+            $products->pluck('id')->toArray()
+        );
+});
+
+test('can add multiple items with some already existing in cart', function () {
+    $products = Product::factory()->count(3)->create([
+        'price' => 19.99,
+    ]);
+
+    $cart = Cart::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+    $this->cartRepository->addItem($cart, $products[0], 3);
+
+    $itemsToAdd = [
+        [
+            'product' => $products[0],
+            'quantity' => 2,
+        ],
+        [
+            'product' => $products[1],
+            'quantity' => 4,
+        ],
+        [
+            'product' => $products[2],
+            'quantity' => 1,
+        ],
+    ];
+
+    $updatedCart = $this->cartRepository->addMultipleItems($cart, $itemsToAdd);
+
+    expect($updatedCart->cartItems)->toHaveCount(3)
+        ->and($updatedCart->cartItems->firstWhere('product_id', $products[0]->id)->quantity)->toBe(5)
+        ->and($updatedCart->cartItems->firstWhere('product_id', $products[1]->id)->quantity)->toBe(4)
+        ->and($updatedCart->cartItems->firstWhere('product_id', $products[2]->id)->quantity)->toBe(1);
+});
+
+test('handles adding multiple items with zero quantity', function () {
+    $products = Product::factory()->count(3)->create([
+        'price' => 19.99,
+    ]);
+
+    $cart = Cart::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $itemsToAdd = [
+        [
+            'product' => $products[0],
+            'quantity' => 2,
+        ],
+        [
+            'product' => $products[1],
+            'quantity' => 0,
+        ],
+        [
+            'product' => $products[2],
+            'quantity' => 1,
+        ],
+    ];
+
+    $updatedCart = $this->cartRepository->addMultipleItems($cart, $itemsToAdd);
+
+    expect($updatedCart->cartItems)->toHaveCount(3)
+        ->and($updatedCart->cartItems->pluck('product_id')->toArray())->toContain(
+            $products[0]->id,
+            $products[2]->id
+        )
+        ->and($updatedCart->cartItems->firstWhere('product_id', $products[0]->id)->quantity)->toBe(2)
+        ->and($updatedCart->cartItems->firstWhere('product_id', $products[2]->id)->quantity)->toBe(1);
+});
+
+test('performance of adding multiple items', function () {
+    $products = Product::factory()->count(100)->create([
+        'price' => 19.99,
+    ]);
+
+    $cart = Cart::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $itemsToAdd = $products->map(function ($product) {
+        return [
+            'product' => $product,
+            'quantity' => rand(1, 10),
+        ];
+    })->toArray();
+
+    $startTime = microtime(true);
+
+    $updatedCart = $this->cartRepository->addMultipleItems($cart, $itemsToAdd);
+
+    $executionTime = microtime(true) - $startTime;
+
+    expect($executionTime)->toBeLessThan(2.0)
+        ->and($updatedCart->cartItems)->toHaveCount(100)
+        ->and($updatedCart->cartItems->sum('quantity'))->toBe(
+            collect($itemsToAdd)->sum('quantity')
+        );
+});

--- a/back/tests/Unit/Services/CartServiceTest.php
+++ b/back/tests/Unit/Services/CartServiceTest.php
@@ -179,6 +179,159 @@ it('can clear the cart', function () {
     expect($result['total_items'])->toBe(0);
 });
 
+it('can add multiple items to the cart', function () {
+    // Arrange
+    $product1 = Mockery::mock(Product::class);
+    $product1->shouldReceive('getAttribute')->with('id')->andReturn(1);
+    $product1->shouldReceive('getAttribute')->with('name')->andReturn('Product 1');
+    $product1->shouldReceive('getAttribute')->with('price')->andReturn(10.00);
+
+    $product2 = Mockery::mock(Product::class);
+    $product2->shouldReceive('getAttribute')->with('id')->andReturn(2);
+    $product2->shouldReceive('getAttribute')->with('name')->andReturn('Product 2');
+    $product2->shouldReceive('getAttribute')->with('price')->andReturn(20.00);
+
+    $cart = new stdClass;
+    $cart->id = 1;
+    $cart->cartItems = collect([
+        (object) [
+            'product' => $product1,
+            'quantity' => 1,
+            'price' => 10.00,
+        ],
+    ]);
+
+    $this->authService->shouldReceive('getCurrentUser')->once()->andReturn(null);
+    $this->sessionService->shouldReceive('getSessionToken')->once()->andReturn('test-session');
+
+    $this->cartRepository
+        ->shouldReceive('findByUserOrSession')
+        ->once()
+        ->with(null, 'test-session')
+        ->andReturn($cart);
+
+    $this->cartRepository
+        ->shouldReceive('addMultipleItems')
+        ->once()
+        ->with($cart, [
+            ['product' => $product1, 'quantity' => 2],
+            ['product' => $product2, 'quantity' => 3],
+        ])
+        ->andReturnUsing(function ($cart, $products) {
+            foreach ($products as $productData) {
+                $product = $productData['product'];
+                $quantity = $productData['quantity'];
+
+                $existingItemIndex = $cart->cartItems->search(function ($item) use ($product) {
+                    return $item->product->id === $product->id;
+                });
+
+                if ($existingItemIndex !== false) {
+                    $cart->cartItems[$existingItemIndex]->quantity += $quantity;
+                } else {
+                    $newItem = (object) [
+                        'product' => $product,
+                        'quantity' => $quantity,
+                        'price' => $product->price,
+                    ];
+                    $cart->cartItems->push($newItem);
+                }
+            }
+
+            return $cart;
+        });
+
+    // Act
+    $cartService = new CartService(
+        $this->cartRepository,
+        $this->authService,
+        $this->sessionService
+    );
+
+    $products = [
+        ['product' => $product1, 'quantity' => 2],
+        ['product' => $product2, 'quantity' => 3],
+    ];
+    $result = $cartService->addMultipleItems($products);
+
+    // Assert
+    expect($result)->toHaveKeys(['id', 'items', 'total', 'total_items']);
+    expect($result['total'])->toBe(90.00);  // (1 + 2) * 10 + 3 * 20
+    expect($result['total_items'])->toBe(6);  // 1 + 2 + 3
+});
+
+it('performs efficiently when adding multiple items', function () {
+    // Arrange
+    $mockProducts = collect(range(1, 100))->map(function ($i) {
+        $product = Mockery::mock(Product::class);
+        $product->shouldReceive('getAttribute')->with('id')->andReturn($i);
+        $product->shouldReceive('getAttribute')->with('price')->andReturn(10.00);
+        $product->shouldReceive('getAttribute')->with('name')->andReturn("Product {$i}");
+
+        return $product;
+    });
+
+    $cart = new stdClass;
+    $cart->id = 1;
+    $cart->cartItems = collect();
+
+    $this->authService->shouldReceive('getCurrentUser')->once()->andReturn(null);
+    $this->sessionService->shouldReceive('getSessionToken')->once()->andReturn('test-session');
+
+    $this->cartRepository
+        ->shouldReceive('findByUserOrSession')
+        ->once()
+        ->with(null, 'test-session')
+        ->andReturn($cart);
+
+    $cartItemsData = $mockProducts->map(function ($product) {
+        return [
+            'product' => $product,
+            'quantity' => rand(1, 10),
+        ];
+    })->toArray();
+
+    $this->cartRepository
+        ->shouldReceive('addMultipleItems')
+        ->once()
+        ->with($cart, $cartItemsData)
+        ->andReturnUsing(function ($cart, $products) {
+            foreach ($products as $productData) {
+                $product = $productData['product'];
+                $quantity = $productData['quantity'];
+
+                $newItem = (object) [
+                    'product' => $product,
+                    'quantity' => $quantity,
+                    'price' => $product->getAttribute('price'),
+                ];
+                $cart->cartItems->push($newItem);
+            }
+
+            return $cart;
+        });
+
+    // Act
+    $cartService = new CartService(
+        $this->cartRepository,
+        $this->authService,
+        $this->sessionService
+    );
+
+    $startTime = microtime(true);
+
+    $result = $cartService->addMultipleItems($cartItemsData);
+
+    $executionTime = microtime(true) - $startTime;
+
+    // Assert
+    expect($executionTime)->toBeLessThan(1.0)
+        ->and($result)->toHaveKeys(['id', 'items', 'total', 'total_items'])
+        ->and($result['total_items'])->toBe(
+            collect($cartItemsData)->sum('quantity')
+        );
+});
+
 afterEach(function () {
     Mockery::close();
 });

--- a/front/src/components/layout/base-layout.tsx
+++ b/front/src/components/layout/base-layout.tsx
@@ -11,7 +11,7 @@ export default function BaseLayout({
     <div className="flex h-screen flex-col overflow-hidden bg-secondary">
       <Nav />
       <main className="relative mx-4 my-3 mr-2 flex-1 overflow-hidden rounded-xl bg-background focus:outline-none md:mx-4 md:my-4 md:ml-4 md:mr-4">
-        <div className="fixed bottom-2 left-2 z-50">
+        <div className="fixed bottom-2 left-2 z-10">
           <ModeToggle />
         </div>
         <ShoppingCartModal />

--- a/front/src/components/shared/shopping-cart-modal.tsx
+++ b/front/src/components/shared/shopping-cart-modal.tsx
@@ -34,7 +34,7 @@ export default function ShoppingCartModal() {
 
           <div className="flex-grow overflow-auto p-4">
             {cartItems.length === 0 ? (
-              <div className="py-8 text-center text-gray-500">Empty cart</div>
+              <div className="py-8 text-center text-primary">Empty cart</div>
             ) : (
               <ul className="space-y-4">
                 {cartItems.map((item) => (
@@ -53,7 +53,10 @@ export default function ShoppingCartModal() {
               <button
                 className="flex w-12 flex-shrink-0 items-center justify-center rounded-md border-2 bg-secondary py-2 font-medium text-red-500 hover:text-red-700 disabled:opacity-50"
                 disabled={cartItems.length === 0}
-                onClick={clearCart}
+                onClick={() => {
+                  clearCart();
+                  closeCart();
+                }}
               >
                 <Trash />
               </button>

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -2,7 +2,8 @@ import axios from 'axios';
 import {
   ApiLoginResponse,
   ApiListResponse,
-  RequestListEndpoint
+  RequestListEndpoint,
+  RequestCartAddMultipleEndpoint
 } from '@/types/api';
 import { JWT_LOCAL_STORAGE_KEY } from '@/constants/local-storage.tsx';
 import { CartItem, Product } from '@/types';
@@ -50,6 +51,10 @@ export async function getProducts(data: RequestListEndpoint) {
 export const cartApi = {
   getCart: async () => {
     return await api.get<CartItem[]>('/api/cart');
+  },
+
+  addMultipleToCart: async (data: RequestCartAddMultipleEndpoint) => {
+    return await api.post<CartItem>(`/api/cart/add-multiple`, data);
   },
 
   addToCart: async (product: Product) => {

--- a/front/src/pages/shop/components/product-card.tsx
+++ b/front/src/pages/shop/components/product-card.tsx
@@ -1,18 +1,47 @@
 import Image from '@/components/ui/image';
 import type { Product } from '@/types';
+import { Check, Minus, Plus } from 'lucide-react';
 
 interface ProductCardProps {
   product: Product;
   onAddToCart: () => void;
+  isSelected: boolean;
+  onToggleSelect: () => void;
+  selectedQuantity: number;
+  onUpdateSelectedQuantity: (quantity: number) => void;
 }
 
 export default function ProductCard({
   product,
-  onAddToCart
+  onAddToCart,
+  isSelected,
+  onToggleSelect,
+  selectedQuantity,
+  onUpdateSelectedQuantity
 }: ProductCardProps) {
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-lg bg-card shadow-md transition-shadow duration-300 hover:shadow-lg">
+    <div
+      className={`
+      flex h-full flex-col overflow-hidden rounded-lg bg-card shadow-md 
+      transition-shadow duration-300 hover:shadow-lg 
+      ${isSelected ? 'ring-2 ring-primary' : ''}
+    `}
+    >
       <div className="relative h-48 overflow-hidden">
+        <div className="absolute left-2 top-2 z-10">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleSelect();
+            }}
+            className={`
+              flex h-6 w-6 items-center justify-center rounded-full 
+              ${isSelected ? 'bg-primary text-white' : 'border border-gray-300 bg-white'}
+            `}
+          >
+            {isSelected && <Check size={14} />}
+          </button>
+        </div>
         <Image
           src={product.image || '/placeholder.svg'}
           alt={product.name}
@@ -28,12 +57,38 @@ export default function ProductCard({
         </p>
         <div className="mt-auto flex items-center justify-between">
           <span className="text-lg font-bold text-primary">{`$${product.price}`}</span>
-          <button
-            onClick={onAddToCart}
-            className="rounded-md bg-primary px-3 py-1 text-sm text-muted transition-colors duration-200 hover:bg-background hover:text-muted-foreground"
-          >
-            Add
-          </button>
+
+          {isSelected ? (
+            <div className="flex items-center rounded-md border-2">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onUpdateSelectedQuantity(Math.max(1, selectedQuantity - 1));
+                }}
+                className="rounded px-2 py-1 text-primary hover:bg-gray-100"
+                disabled={selectedQuantity <= 1}
+              >
+                <Minus size={14} />
+              </button>
+              <span className="px-2 py-1">{selectedQuantity}</span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onUpdateSelectedQuantity(selectedQuantity + 1);
+                }}
+                className="rounded px-2 py-1 text-primary hover:bg-gray-100"
+              >
+                <Plus size={14} />
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={onAddToCart}
+              className="rounded-md bg-primary px-3 py-1 text-sm text-muted transition-colors duration-200 hover:bg-background hover:text-muted-foreground"
+            >
+              Add
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/front/src/pages/shop/components/product-grid.tsx
+++ b/front/src/pages/shop/components/product-grid.tsx
@@ -1,16 +1,26 @@
 import { useGetInfiniteProducts } from '@/pages/shop/queries/queries.ts';
 import { Product } from '@/types';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Loader from '@/components/shared/loader.tsx';
 import ProductCard from '@/pages/shop/components/product-card.tsx';
 import { useCart } from '@/hooks/use-cart.tsx';
 import { useInView } from 'react-intersection-observer';
 
 export default function ProductGrid() {
-  const { addToCart } = useCart();
+  const { addToCart, addMultipleToCart } = useCart();
   const { ref, inView } = useInView();
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
-    useGetInfiniteProducts();
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    status,
+    isError,
+    error
+  } = useGetInfiniteProducts();
+  const [selectedProducts, setSelectedProducts] = useState<Map<string, number>>(
+    new Map()
+  );
 
   useEffect(() => {
     if (inView && hasNextPage) {
@@ -18,7 +28,7 @@ export default function ProductGrid() {
     }
   }, [inView, hasNextPage, fetchNextPage]);
 
-  if (status === 'error') {
+  if (status === 'error' || isError || error) {
     return (
       <div className="grid h-full place-content-center">
         Error when loading products
@@ -26,8 +36,77 @@ export default function ProductGrid() {
     );
   }
 
+  const products = data?.pages.flatMap((page) => page.data) || [];
+
+  const toggleProductSelection = (productId: string) => {
+    setSelectedProducts((prev) => {
+      const newMap = new Map(prev);
+      if (newMap.has(productId)) {
+        newMap.delete(productId);
+      } else {
+        newMap.set(productId, 1);
+      }
+      return newMap;
+    });
+  };
+
+  const updateSelectedQuantity = (productId: string, quantity: number) => {
+    if (quantity <= 0) {
+      setSelectedProducts((prev) => {
+        const newMap = new Map(prev);
+        newMap.delete(productId);
+        return newMap;
+      });
+      return;
+    }
+
+    setSelectedProducts((prev) => {
+      const newMap = new Map(prev);
+      newMap.set(productId, quantity);
+      return newMap;
+    });
+  };
+
+  const addSelectedToCart = () => {
+    if (selectedProducts.size === 0) return;
+
+    const productsToAdd = Array.from(selectedProducts.entries()).map(
+      ([id, quantity]) => {
+        const product = products.find((p) => p.id === id);
+        if (!product) throw new Error(`Product with id ${id} not found`);
+        return { product, quantity };
+      }
+    );
+
+    addMultipleToCart(productsToAdd);
+    setSelectedProducts(new Map());
+  };
+
+  const totalSelectedItems = Array.from(selectedProducts.values()).reduce(
+    (sum, quantity) => sum + quantity,
+    0
+  );
+
   return (
     <div className="relative">
+      {selectedProducts.size > 0 && (
+        <div className="fixed bottom-2 right-2 z-40 flex flex-col items-end space-y-2">
+          <div className="flex items-center space-x-2 rounded-lg bg-accent p-3 shadow-lg">
+            <span className="text-sm font-medium">
+              {selectedProducts.size}{' '}
+              {selectedProducts.size === 1 ? 'product' : 'products'} selected (
+              {totalSelectedItems} {totalSelectedItems === 1 ? 'item' : 'items'}
+              )
+            </span>
+            <button
+              onClick={addSelectedToCart}
+              className="rounded-md bg-primary px-3 py-1 text-sm text-muted transition-colors duration-200 hover:bg-background hover:text-muted-foreground"
+            >
+              <span>Add</span>
+            </button>
+          </div>
+        </div>
+      )}
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data?.pages.map((page) =>
           page.data.map((product: Product) => (
@@ -35,6 +114,12 @@ export default function ProductGrid() {
               key={product.id}
               product={product}
               onAddToCart={() => addToCart(product)}
+              isSelected={selectedProducts.has(product.id)}
+              onToggleSelect={() => toggleProductSelection(product.id)}
+              selectedQuantity={selectedProducts.get(product.id) || 0}
+              onUpdateSelectedQuantity={(quantity) =>
+                updateSelectedQuantity(product.id, quantity)
+              }
             />
           ))
         )}

--- a/front/src/pages/shop/components/shopping-cart-item.tsx
+++ b/front/src/pages/shop/components/shopping-cart-item.tsx
@@ -24,11 +24,11 @@ export default function ShoppingCartItem({ item }: ShoppingCartItemProps) {
         </div>
         <div className="flex-grow">
           <h3 className="font-medium">{item.product.name}</h3>
-          <p className="text-gray-600">${item.product.price}</p>
+          <p className="text-primary">${item.product.price}</p>
           <div className="mt-2 flex items-center">
             <button
               onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
-              className="flex h-8 w-8 items-center justify-center rounded-l border"
+              className="flex h-8 w-8 items-center justify-center rounded-l border text-primary"
             >
               -
             </button>
@@ -37,7 +37,7 @@ export default function ShoppingCartItem({ item }: ShoppingCartItemProps) {
             </span>
             <button
               onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
-              className="flex h-8 w-8 items-center justify-center rounded-r border"
+              className="flex h-8 w-8 items-center justify-center rounded-r border text-primary"
             >
               +
             </button>

--- a/front/src/types/api.tsx
+++ b/front/src/types/api.tsx
@@ -24,6 +24,13 @@ export interface RequestListEndpoint {
   paginator_mode?: number;
 }
 
+export interface RequestCartAddMultipleEndpoint {
+  items: {
+    product_id: number;
+    quantity: number;
+  }[];
+}
+
 export interface PaginationResponse<T> {
   current_page: number;
   data: T[];

--- a/front/src/types/index.tsx
+++ b/front/src/types/index.tsx
@@ -44,6 +44,9 @@ export interface CartContextType {
   clearCart: () => void;
   closeCart: () => void;
   addToCart: (product: Product) => void;
+  addMultipleToCart: (
+    products: { product: Product; quantity: number }[]
+  ) => void;
   removeFromCart: (productId: string) => void;
   updateQuantity: (productId: string, quantity: number) => void;
   totalItems: number;


### PR DESCRIPTION
feat(cart): add support for adding multiple products to cart

- back:
    - Implement multiple product addition in `CartService`, `CartController`, and `CartRepository`.
    - Add unit tests for `CartServiceTest`, `CartControllerTest`, and `CartRepositoryTest`.
    - Introduce `AddMultipleItemsRequest` for request validation.
    - Register new API route in `api.php`.

- front:
    - Extend `cart-provider` to support bulk product addition.
    - Update `product-grid` to enable multiple product selection.
    - Refactor UI to enhance user experience when adding multiple products.